### PR TITLE
Set directory separator manually.

### DIFF
--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -295,9 +295,11 @@ void display_primary_prompt(char const* git_info, int shlvl)
  *****************************************************************************/
 void set_terminal_title(std::filesystem::path const& pwd)
 {
-    // Using the divide overload with the empty string does not append the
-    // directory separator, so do it manually.
-    std::filesystem::path::value_type sep = std::filesystem::path::preferred_separator;
+#ifdef _WIN32
+    char sep = '\\';
+#else
+    char sep = '/';
+#endif
     std::clog << ESCAPE RIGHT_SQUARE_BRACKET "0;" << pwd.filename().string() << sep << ESCAPE BACKSLASH;
 }
 


### PR DESCRIPTION
On Windows, `std::filesystem::path::preferred_separator` is of type `wchar_t`, which `clog` displays as an integer. There is no quick and easy way to convert a `wchar_t` to a `char`, so doing it manually.