### PR TITLE
Removed note about binaries being dynamically-linked.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -62,7 +62,7 @@ jobs:
           done
         name: Create compressed archives of executable binaries
       - run: |
-          gh release create ${{ github.ref_name }} -t ${{ github.ref_name }} --notes 'Binaries are dynamically-linked.' --generate-notes
+          gh release create ${{ github.ref_name }} -t ${{ github.ref_name }} --generate-notes
           gh release upload ${{ github.ref_name }} */*.tgz
         name: Publish release
         env:


### PR DESCRIPTION
The Windows binary is statically-linked. But not really: only the C and C++ standard libraries appear to be pulled in with `-static` in `Makefile`. No idea what that actually means! Best not to make a claim about the nature of the binaries.