### PR TITLE
`string_view::remove_prefix` instead of reassigning `last_command`

### DIFF
--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -286,7 +286,7 @@ void report_command_status(std::string_view& last_command, int exit_code, long l
 
 #ifdef BASH
     // Remove the initial part (index and timestamp) of the command.
-    last_command = last_command.substr(last_command.find(RIGHT_SQUARE_BRACKET[0]) + 2);
+    last_command.remove_prefix(last_command.find(RIGHT_SQUARE_BRACKET[0]) + 2);
 #endif
     last_command.remove_suffix(last_command.size() - 1 - last_command.find_last_not_of(' '));
     LOG_DEBUG("Command length is %zu.", last_command.size());


### PR DESCRIPTION
Closes #46.