### PR TITLE
Missing Zsh completions

### DIFF
--- a/.local/share/bash-completion/completions/pipx
+++ b/.local/share/bash-completion/completions/pipx
@@ -1,0 +1,1 @@
+. <(register-python-argcomplete pipx)

--- a/.local/share/zsh-completions/completions/_hatch
+++ b/.local/share/zsh-completions/completions/_hatch
@@ -1,0 +1,3 @@
+#compdef hatch
+
+. <(_HATCH_COMPLETE=zsh_source hatch)

--- a/.local/share/zsh-completions/completions/_pipenv
+++ b/.local/share/zsh-completions/completions/_pipenv
@@ -1,0 +1,3 @@
+#compdef pipenv
+
+. <(_PIPENV_COMPLETE=zsh_source pipenv)

--- a/.local/share/zsh-completions/completions/_pipx
+++ b/.local/share/zsh-completions/completions/_pipx
@@ -1,0 +1,3 @@
+#compdef pipx
+
+. <(register-python-argcomplete pipx)

--- a/.zshrc
+++ b/.zshrc
@@ -228,6 +228,8 @@ zstyle ':completion:*' special-dirs true
 # 'type' as specified in `LS_COLORS`), display it without any colour.
 zstyle -e ':completion:*:default' list-colors 'PREFIX=${PREFIX##*/} && reply=("${PREFIX:+=(#b)($PREFIX)(*)=0=1;90=0}:$LS_COLORS")'
 
+# Needed for some programs (like pipx) which supply only Bash completion
+# scripts.
 bashcompinit
 
 select-word-style bash

--- a/.zshrc
+++ b/.zshrc
@@ -207,13 +207,15 @@ unset SSH_ASKPASS
 ###############################################################################
 # Built-in functions.
 ###############################################################################
-autoload -Uz add-zsh-hook compinit select-word-style
+autoload -Uz add-zsh-hook bashcompinit compinit select-word-style
 
 # Load these and immediately execute them (Zsh does not do so automatically)
 # because they help set the primary prompt.
 add-zsh-hook precmd _after_command
 add-zsh-hook preexec _before_command
 _before_command && _after_command
+
+bashcompinit
 
 compinit
 zstyle ':completion:*' file-sort name

--- a/.zshrc
+++ b/.zshrc
@@ -215,8 +215,7 @@ add-zsh-hook precmd _after_command
 add-zsh-hook preexec _before_command
 _before_command && _after_command
 
-bashcompinit
-
+# Must be called before the Bash equivalent, according the manual.
 compinit
 zstyle ':completion:*' file-sort name
 zstyle ':completion:*' insert-tab false
@@ -228,6 +227,8 @@ zstyle ':completion:*' special-dirs true
 # any colour. Furthermore, if a completion word is a file (of any type, with
 # 'type' as specified in `LS_COLORS`), display it without any colour.
 zstyle -e ':completion:*:default' list-colors 'PREFIX=${PREFIX##*/} && reply=("${PREFIX:+=(#b)($PREFIX)(*)=0=1;90=0}:$LS_COLORS")'
+
+bashcompinit
 
 select-word-style bash
 


### PR DESCRIPTION
I had not added the Zsh completion scripts for some programs though I had added their Bash equivalents, because I thought `zsh-completions` provides all the required scripts. That package is available on EndeavourOS, but not Peppermint or Mint. Even if it were, the best way to install programs like Hatch and Pipenv on Debian-based systems is through pipx, which does not install their Zsh completions scripts. Hence, best add those scripts here. It's not much effort.