### PR TITLE
Strict aliasing

### DIFF
--- a/custom-prompt/Makefile
+++ b/custom-prompt/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
-CFLAGS = -std=c11 -Wall -Wextra
-CXXFLAGS = -std=c++17 -Wall -Wextra
+CFLAGS = -fstrict-aliasing -std=c11 -Wall -Wextra
+CXXFLAGS = -fstrict-aliasing -std=c++17 -Wall -Wextra
 LDLIBS = -lstdc++
 
 MainSource = custom-prompt.cc


### PR DESCRIPTION
According to the GCC manual, this flag is automatically added when optimisations are enabled, but I would like to always have it.