### PR TITLE
Restore reading current directory from shell

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -114,7 +114,7 @@ _after_command()
     local exit_code=$?
     [ -z "${__begin_window+.}" ] && return
     local last_command=$(history 1)
-    PS1=$(custom-bash-prompt "$last_command" $exit_code $__begin_window $COLUMNS "$(__git_ps1 %s)" $SHLVL)
+    PS1=$(custom-bash-prompt "$last_command" $exit_code $__begin_window $COLUMNS "$(__git_ps1 %s)" $SHLVL "$PWD")
     unset __begin_window
 }
 

--- a/.zshrc
+++ b/.zshrc
@@ -6,7 +6,7 @@ _after_command()
     local exit_code=$?
     [ -z "${__begin_window+.}" ] && return
     local last_command=$(history -n -1 2>/dev/null)
-    PS1=$(custom-zsh-prompt "$last_command" $exit_code $=__begin_window $COLUMNS "$(__git_ps1 %s)" $SHLVL)
+    PS1=$(custom-zsh-prompt "$last_command" $exit_code $=__begin_window $COLUMNS "$(__git_ps1 %s)" $SHLVL $PWD)
     unset __begin_window
 }
 

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
-#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -342,12 +341,12 @@ void display_primary_prompt(char const* git_info, int shlvl)
  *
  * @param pwd Current directory.
  *****************************************************************************/
-void set_terminal_title(std::filesystem::path const& pwd)
+void set_terminal_title(std::string_view & pwd)
 {
-    // The result of converting wide characters to narrow characters, which is
-    // what this line will do on Windows, is unspecified. I can only hope that
-    // nothing goes wrong. (All is good with GCC.)
-    std::clog << ESCAPE RIGHT_SQUARE_BRACKET "0;" << pwd.filename().string() << '/' << ESCAPE BACKSLASH;
+    LOG_DEBUG("Current directory path is '%s'.", pwd.data());
+    pwd.remove_prefix(pwd.rfind('/') + 1);
+    LOG_DEBUG("Current directory name is '%s'.", pwd.data());
+    std::clog << ESCAPE RIGHT_SQUARE_BRACKET "0;" << pwd << '/' << ESCAPE BACKSLASH;
 }
 
 /******************************************************************************
@@ -373,7 +372,7 @@ int main_internal(int const argc, char const* argv[])
     // null-terminated.
     if (argc == 2)
     {
-        char const* argv[] = { "custom-prompt", "[] last_command", "0", "0", "0", "79", "git_info", "1", nullptr };
+        char const* argv[] = { "custom-prompt", "[] last_command", "0", "0", "0", "79", "git_info", "1", "", nullptr };
         int constexpr argc = sizeof argv / sizeof *argv - 1;
         return main_internal(argc, argv);
     }
@@ -389,7 +388,7 @@ int main_internal(int const argc, char const* argv[])
     int shlvl = std::stoi(argv[7]);
     display_primary_prompt(git_info, shlvl);
 
-    std::filesystem::path pwd = std::filesystem::current_path();
+    std::string_view pwd(argv[8]);
     set_terminal_title(pwd);
 
     return EXIT_SUCCESS;

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -372,7 +372,7 @@ int main_internal(int const argc, char const* argv[])
     // null-terminated.
     if (argc == 2)
     {
-        char const* argv[] = { "custom-prompt", "[] last_command", "0", "0", "0", "79", "git_info", "1", "", nullptr };
+        char const* argv[] = { "custom-prompt", "[] last_command", "0", "0", "0", "79", "main", "1", "/", nullptr };
         int constexpr argc = sizeof argv / sizeof *argv - 1;
         return main_internal(argc, argv);
     }

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -341,7 +341,7 @@ void display_primary_prompt(char const* git_info, int shlvl)
  *
  * @param pwd Current directory.
  *****************************************************************************/
-void set_terminal_title(std::string_view & pwd)
+void set_terminal_title(std::string_view& pwd)
 {
     LOG_DEBUG("Current directory path is '%s'.", pwd.data());
     pwd.remove_prefix(pwd.rfind('/') + 1);


### PR DESCRIPTION
Obtaining the current directory from C++ was implemented in d5bf60c4bc75ee0ba159bd636171a4d650aa5c7a. (This commit changes it back to how it was earlier.) It probably involves a system call. Better to use the environment variable in Bash and Zsh. Furthermore, in C++, the working directory is a wide-character string on Windows, so it cannot be safely printed to the error stream because it gets auto-configured to print narrow-character strings the moment the first item (which is a narrow-character string) gets printed. (Although GCC and Clang do not mess up the error stream, the C++ standard says that this might happen, because printing narrow- and wide-character strings to the same stream results in undefined behaviour, so I would rather not do that.) To convert a wide-character string to narrow character string, the standard recommends using dedicated text-processing libraries, having deprecated the standard library functions for the same in C++17 (https://stackoverflow.com/q/42946335). Why deal with all that headache when the shell can supply the current directory.