### PR TITLE
Scrap useless `filecmp` for custom implementation

### DIFF
--- a/diff/diff.py
+++ b/diff/diff.py
@@ -167,13 +167,13 @@ class Diff:
         for common_file in common_files:
             left_right_file_mapping[common_file] = common_file
 
-        for file in sorted([*common_files, *self._left_directory_files, *self._right_directory_files]):
+        for file in sorted([*self._left_directory_files, *self._right_directory_files, *left_right_file_mapping]):
             if file in self._left_directory_files:
                 self._report(self._read_lines(os.path.join(self._left_directory, file)), [], file, "[deleted]")
             elif file in self._right_directory_files:
                 self._report([], self._read_lines(os.path.join(self._right_directory, file)), "[added]", file)
             else:
-                self._report(self._read_lines(os.path.join(self._left_directory, file)), self._read_lines(os.path.join(self._right_directory, file)), file, file)
+                self._report(self._read_lines(os.path.join(self._left_directory, file)), self._read_lines(os.path.join(self._right_directory, left_right_file_mapping[file])), file, file)
 
 
 def main():

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import difflib
-import filecmp
 import fileinput
 import os
 import sys

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -79,12 +79,12 @@ class Diff:
         :param directory: Directory path.
         :return: Files in the tree rooted at the given directory.
         """
-        files = []
+        files = set()
         for root, _, file_names in os.walk(directory):
             for file_name in file_names:
                 file = os.path.join(root, file_name).removeprefix(directory)
-                files.append(file)
-        return {*files}
+                files.add(file)
+        return files
 
     @staticmethod
     def _read_lines(source: str) -> list[str]:

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -71,6 +71,9 @@ class Diff:
         self._left_directory_files = self._files_in(self._left_directory)
         self._right_directory = right
         self._right_directory_files = self._files_in(self._right_directory)
+        self._common_files = self._left_directory_files.intersection(self._right_directory_files)
+        self._left_directory_files -= self._common_files
+        self._right_directory_files -= self._common_files
         self._writer = writer
         self._matcher = difflib.SequenceMatcher(autojunk=False)
         self._html_diff = difflib.HtmlDiff(wrapcolumn=119)
@@ -110,9 +113,6 @@ class Diff:
         Write HTML tables summarising the recursive differences between two
         directories.
         """
-        common_files = self._left_directory_files.intersection(self._right_directory_files)
-        self._left_directory_files -= common_files
-        self._right_directory_files -= common_files
         left_directory_file_matches = collections.defaultdict(list)
         for left_directory_file, right_directory_file in itertools.product(
             self._left_directory_files, self._right_directory_files
@@ -137,7 +137,7 @@ class Diff:
         )
 
         # Files which were changed without renaming.
-        left_right_file_mapping = {common_file: common_file for common_file in common_files}
+        left_right_file_mapping = {common_file: common_file for common_file in self._common_files}
 
         # Detect renames by mapping a file in the left directory to one in the
         # right.

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -61,8 +61,7 @@ html_end = b"""
 
 class Diff:
     """
-    Compare two directories recursively. Does not handle renames and additions
-    or deletions of directories correctly.
+    Compare two directories recursively.
     """
 
     def __init__(self, left: str, right: str, writer):
@@ -149,14 +148,13 @@ class Diff:
                     right_directory_file_matches[right_directory_file].append((similarity_ratio, left_directory_file))
         for v in left_directory_file_matches.values():
             v.sort()
+        left_directory_file_matches = dict(sorted(left_directory_file_matches.items(), key=lambda kv: kv[1][-1][0] if kv[1] else 0))
         for v in right_directory_file_matches.values():
             v.sort()
-        print(left_directory_file_matches)
-        print(right_directory_file_matches)
 
         left_right_file_mapping = {}
         for left_directory_file, v in left_directory_file_matches.items():
-            if left_directory_file in left_right_file_mapping or not v:
+            if not v or left_directory_file in left_right_file_mapping:
                 continue
             for _, similar_right_directory_file in reversed(v):
                 if similar_right_directory_file not in right_directory_file_matches:
@@ -164,9 +162,13 @@ class Diff:
                 _, similar_left_directory_file = right_directory_file_matches[similar_right_directory_file][-1]
                 left_right_file_mapping[similar_left_directory_file] = similar_right_directory_file
                 del right_directory_file_matches[similar_right_directory_file]
+                self._left_directory_files.remove(similar_left_directory_file)
+                self._right_directory_files.remove(similar_right_directory_file)
         for common_file in common_files:
             left_right_file_mapping[common_file] = common_file
-        for item in left_right_file_mapping.items(): print(item)
+        for item in left_right_file_mapping.items(): print("=", item)
+        for item in self._left_directory_files: print("D", item)
+        for item in self._right_directory_files: print("A", item)
 
 
 def main():
@@ -180,3 +182,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -85,12 +85,11 @@ class Diff:
         :param directory: Absolute directory path.
         :return: Files in the tree rooted at the given directory.
         """
-        files = set()
-        for root, _, file_names in os.walk(directory):
-            for file_name in file_names:
-                file = os.path.join(root, file_name).removeprefix(directory)
-                files.add(file)
-        return files
+        return {
+            os.path.join(root, file_name).removeprefix(directory)
+            for root, _, file_names in os.walk(directory)
+            for file_name in file_names
+        }
 
     @staticmethod
     def _read_lines(source: str) -> list[str]:
@@ -151,7 +150,7 @@ class Diff:
                 if similar_right_directory_file not in self._right_directory_files:
                     continue
                 left_right_file_mapping[left_directory_file] = similar_right_directory_file
-                self._left_directory_files.remove(similar_left_directory_file)
+                self._left_directory_files.remove(left_directory_file)
                 self._right_directory_files.remove(similar_right_directory_file)
                 break
 

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -70,15 +70,9 @@ class Diff:
         self._right_directory_files = self._files_in(self._right_directory)
         self._writer = writer
         self._html_diff = difflib.HtmlDiff(wrapcolumn=119)
-        print(self._left_directory)
-        for file in self._left_directory_files:
-            print(file)
-        print(self._right_directory)
-        for file in self._right_directory_files:
-            print(file)
-        raise SystemExit
 
-    def _files_in(self, directory: str) -> list[str]:
+
+    def _files_in(self, directory: str) -> set[str]:
         """
         Recursively list the relative paths of all files in the given
         directory.
@@ -90,7 +84,7 @@ class Diff:
             for file_name in file_names:
                 file = os.path.join(root, file_name).removeprefix(directory)
                 files.append(file)
-        return sorted(files)
+        return {*files}
 
     @staticmethod
     def _read_lines(source: str) -> list[str]:

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -63,10 +63,34 @@ class Diff:
     or deletions of directories correctly.
     """
 
-    def __init__(self, a: str, b: str, writer):
-        self._directory_comparison = filecmp.dircmp(a, b, shallow=False)
+    def __init__(self, left: str, right: str, writer):
+        self._left_directory = left
+        self._left_directory_files = self._files_in(self._left_directory)
+        self._right_directory = right
+        self._right_directory_files = self._files_in(self._right_directory)
         self._writer = writer
         self._html_diff = difflib.HtmlDiff(wrapcolumn=119)
+        print(self._left_directory)
+        for file in self._left_directory_files:
+            print(file)
+        print(self._right_directory)
+        for file in self._right_directory_files:
+            print(file)
+        raise SystemExit
+
+    def _files_in(self, directory: str) -> list[str]:
+        """
+        Recursively list the relative paths of all files in the given
+        directory.
+        :param directory: Directory path.
+        :return: Files in the tree rooted at the given directory.
+        """
+        files = []
+        for root, _, file_names in os.walk(directory):
+            for file_name in file_names:
+                file = os.path.join(root, file_name).removeprefix(directory)
+                files.append(file)
+        return sorted(files)
 
     @staticmethod
     def _read_lines(source: str) -> list[str]:
@@ -107,7 +131,7 @@ class Diff:
         self._writer.write(b"</details>\n")
         self._writer.write(html_separator)
 
-    def report(self, directory_comparison: filecmp.dircmp | None = None):
+    def report(self, directory_comparison = None):
         """
         Write an HTML table summarising the differences recorded between two
         directories. Then recurse on their subdirectories.

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -164,7 +164,7 @@ class Diff:
                     self._read_lines(os.path.join(self._left_directory, file)),
                     self._read_lines(os.path.join(self._right_directory, left_right_file_mapping[file])),
                     file,
-                    file,
+                    left_right_file_mapping[file],
                 )
 
 

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -166,9 +166,14 @@ class Diff:
                 self._right_directory_files.remove(similar_right_directory_file)
         for common_file in common_files:
             left_right_file_mapping[common_file] = common_file
-        for item in left_right_file_mapping.items(): print("=", item)
-        for item in self._left_directory_files: print("D", item)
-        for item in self._right_directory_files: print("A", item)
+
+        for file in sorted([*common_files, *self._left_directory_files, *self._right_directory_files]):
+            if file in self._left_directory_files:
+                self._report(self._read_lines(os.path.join(self._left_directory, file)), [], file, "[deleted]")
+            elif file in self._right_directory_files:
+                self._report([], self._read_lines(os.path.join(self._right_directory, file)), "[added]", file)
+            else:
+                self._report(self._read_lines(os.path.join(self._left_directory, file)), self._read_lines(os.path.join(self._right_directory, file)), file, file)
 
 
 def main():

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -131,6 +131,10 @@ class Diff:
         directories. Then recurse on their subdirectories.
         :param directory_comparison: Directory comparison object.
         """
+        self._common_files = self._left_directory_files.intersection(self._right_directory_files)
+        self._left_directory_files -= self._common_files
+        self._right_directory_files -= self._common_files
+
         directory_comparison = directory_comparison or self._directory_comparison
         for deleted_file in directory_comparison.left_only:
             deleted_file_path = os.path.join(directory_comparison.left, deleted_file)

--- a/diff/pyproject.toml
+++ b/diff/pyproject.toml
@@ -18,4 +18,5 @@ classifiers = [
 [tool.ruff]
 line-length = 119
 
-[tool.ruff.lint.per-file-ignores]
+[tool.ruff.lint]
+ignore = []

--- a/diff/pyproject.toml
+++ b/diff/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "diff"
+version = "0.0.0"
+authors = [
+    { name = "Vishal Pankaj Chandratreya" },
+]
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+]
+
+[tool.ruff]
+line-length = 119
+
+[tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
`filecmp` does not detect renames, and does not list newly-added files if they are in a newly-added directory. This makes it unfit for diffing two directory trees. Implement the required functionality manually.