### PR TITLE
Specify encoding for `FileInput`

### DIFF
--- a/.pythonstartup.py
+++ b/.pythonstartup.py
@@ -26,6 +26,7 @@ import importlib
 import io
 import itertools
 import json
+import locale
 import logging
 import math
 import multiprocessing

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -97,7 +97,7 @@ class Diff:
         :param source: File to read.
         :return: File contents.
         """
-        return fileinput.FileInput(source)
+        return fileinput.FileInput(source, encoding="utf-8")
 
     def _changed_not_renamed_mapping(self) -> dict[str, str]:
         """


### PR DESCRIPTION
It uses CP-1252 on Windows, which chokes on the multi-byte characters I have used with abandon in my projects. A funny bug results: files containing such characters are marked as binary by `diff.py`, even if they are text files. This happens because the exception raised is the same one I catch to detect when a binary file is opened.

Also, `locale` is now imported in the Python REPL.