### PR TITLE
`diff.py`: calculate hashes in main process

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -6,7 +6,7 @@
 	statusUoption = false
 [alias]
 	d = diff -w
-	dd = git difftool -d -t custom
+	dd = difftool -d -t custom
 	l = log --graph --pretty='%C(yellow)%h%C(reset) %C(brightblack)%cd%C(reset) %C(cyan)%>|(64,trunc)%an%C(reset) %C(auto)%(decorate:pointer= ,prefix=,separator= ,suffix= ,tag=)%C(reset)%<|(-1,trunc)%s'
 	ll = l --all
 	s = show -w

--- a/.gitconfig
+++ b/.gitconfig
@@ -6,8 +6,7 @@
 	statusUoption = false
 [alias]
 	d = diff -w
-	# Disable Python hash randomisation in the custom diff tool.
-	dd = "!export PYTHONHASHSEED=0 && git difftool -d -t custom"
+	dd = git difftool -d -t custom
 	l = log --graph --pretty='%C(yellow)%h%C(reset) %C(brightblack)%cd%C(reset) %C(cyan)%>|(64,trunc)%an%C(reset) %C(auto)%(decorate:pointer= ,prefix=,separator= ,suffix= ,tag=)%C(reset)%<|(-1,trunc)%s'
 	ll = l --all
 	s = show -w

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -134,6 +134,7 @@ class Diff:
         left_directory_lookup = defaultdict(list)
         for left_file in self._left_files:
             left_file_contents = left_file.read_bytes()
+            # Assume there are no collisions.
             left_directory_lookup[hash(left_file_contents)].append(left_file)
 
         left_right_file_mapping = {}

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -124,10 +124,6 @@ class Diff:
 
         return left_right_file_mapping
 
-    @staticmethod
-    def _renamed_not_changed_mapping_worker(file: Path) -> int:
-        return hash(file.read_bytes())
-
     @functools.cached_property
     def _renamed_not_changed_mapping(self) -> dict[Path, Path]:
         """
@@ -136,9 +132,9 @@ class Diff:
         :return: Mapping between left and right directory files.
         """
         left_directory_lookup = defaultdict(list)
-        results = self._pool.map_async(self._renamed_not_changed_mapping_worker, self._left_files).get()
-        for left_file, left_file_hash in zip(self._left_files, results, strict=True):
-            left_directory_lookup[left_file_hash].append(left_file)
+        for left_file in self._left_files:
+            left_file_contents = left_file.read_bytes()
+            left_directory_lookup[hash(left_file_contents)].append(left_file)
 
         left_right_file_mapping = {}
         for right_file in self._right_files.copy():

--- a/diff/diff.py.sh
+++ b/diff/diff.py.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env sh
+
+# The external diff tool relies on the built-in hash function in Python being
+# deterministic across interpreter sessions. (Hashes of files are calculated in
+# difference processes.) Hence, disable hash randomisation.
+export PYTHONHASHSEED=0

--- a/diff/diff.py.sh
+++ b/diff/diff.py.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/env sh
-
-# The external diff tool relies on the built-in hash function in Python being
-# deterministic across interpreter sessions. (Hashes of files are calculated in
-# difference processes.) Hence, disable hash randomisation.
-export PYTHONHASHSEED=0


### PR DESCRIPTION
~`diff.py` relies on `hash` returning the same result for the same input across Python processes. Disable hash randomisation to ensure this. Else, exact renames are not detected correctly, because hashes of files are calculated in different processes.~