### PR TITLE
`diff.py`: use words to calculate similarity, not letters

### DIFF
--- a/diff/diff.py
+++ b/diff/diff.py
@@ -63,6 +63,7 @@ deleted_header = '/<span class="deleted_header">−−−−−</span>'
 
 rename_detect_real_quick_threshold, rename_detect_quick_threshold, rename_detect_threshold = 0.5, 0.5, 0.5
 
+Path.relative_to = functools.cache(Path.relative_to)
 
 
 class Diff:

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -63,7 +63,6 @@ deleted_header = '/<span class="deleted_header">−−−−−</span>'
 
 rename_detect_real_quick_threshold, rename_detect_quick_threshold, rename_detect_threshold = 0.5, 0.5, 0.5
 
-Path.relative_to = functools.cache(Path.relative_to)
 
 
 class Diff:

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -63,7 +63,7 @@ html_end = b"""
 added_header = '/<span class="added_header">+++++</span>'
 deleted_header = '/<span class="deleted_header">−−−−−</span>'
 
-rename_detect_real_quick_threshold, rename_detect_quick_threshold, rename_detect_threshold = 0.7, 0.6, 0.5
+rename_detect_real_quick_threshold, rename_detect_quick_threshold, rename_detect_threshold = 0.5, 0.5, 0.5
 
 Path.relative_to = functools.cache(Path.relative_to)
 
@@ -153,7 +153,7 @@ class Diff:
     @staticmethod
     def _renamed_and_changed_mapping_worker(left_file: Path, right_file: Path) -> int:
         try:
-            left_file_contents, right_file_contents = left_file.read_text(), right_file.read_text()
+            left_file_contents, right_file_contents = left_file.read_text().split(), right_file.read_text().split()
         except UnicodeDecodeError:
             return 0
         matcher = difflib.SequenceMatcher(None, left_file_contents, right_file_contents, False)


### PR DESCRIPTION
Just the first commit significantly speeds up the program!

|Repository|Command|Time (Before)|Time (After)|
|:-|:-|-:|-:|
|[ScrollableContainers](https://github.com/tfpf/ScrollableContainers)|`git ss 589e77e`|1.08 s|0.26 s|
|[iitkgp-assignments](https://github.com/tfpf/iitkgp-assignments)|`git dd c39fb83 648aa3f`|9.35 s|0.27 s|
|[sieve-of-atkin](https://github.com/tfpf/sieve-of-atkin)|`git ss 75f0fea`|1.14 s|0.25 s|