### PR TITLE
Show commit metadata when running `git ss`

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -11,7 +11,7 @@
 	l = log --graph --pretty='%C(yellow)%h%C(reset) %C(brightblack)%cd%C(reset) %C(cyan)%>|(64,trunc)%an%C(reset) %C(auto)%(decorate:pointer= ,prefix=,separator= ,suffix= ,tag=)%C(reset)%<|(-1,trunc)%s'
 	ll = l --all
 	s = show -w
-	ss = "!ss() { rev=${1:-HEAD} && right=$(git rev-parse \"$rev\") && left=$(git rev-parse \"$right^\" 2>/dev/null) || left=$(git mktree </dev/null) && sh -cx \"git dd \"$left\" \"$right\"\"; }; ss"
+	ss = "!ss() { rev=${1:-HEAD} && right=$(git rev-parse \"$rev\") && left=$(git rev-parse \"$right^\" 2>/dev/null) || left=$(git mktree </dev/null) && COMMIT_METADATA=$(git show -s \"$right\") sh -cx \"git dd \"$left\" \"$right\"\"; }; ss"
 	st = status
 [blame]
 	coloring = repeatedLines

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
       - run: |
           cp .gitconfig ~
           sudo cp diff/diff.py /usr/bin
-          test $(sha256sum $(git ss a257771) | awk '{print $1}') = 60fbe012eec89e6dfd8fbe335e255758bd64a285b23d6a88122601112532956f
+          test $(sha256sum $(git ss a257771) | awk '{print $1}') = 5d9029a685981d885c8f2d526f4b4fcbb12864c01ee910093880c75125921450
         name: Verify diff hash

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -44,7 +44,8 @@ html_begin = b"""
         .diff_header {background-color: #e8f2ff;}
         td.diff_header {text-align: right;}
         body {background-color: #fdfbf3; display: inline-block; font-family: monospace; padding-bottom: 100vh;}
-        details {display: inline-block; margin: 0px 4px 80px 4px;}
+        div {margin: 0px 4px 80px 4px;}
+        details {display: inline-block;}
         summary {background-color: #e8f2ff; border-width: 1px 1px 1px 1px; border-style: solid; cursor: pointer; padding: 0px 4px 0px 4px; position: sticky; top: 0px;}
         details[open] summary {border-bottom-color: #e8f2ff;}
         .diff_next {background-color: #e8f2ff;}
@@ -221,6 +222,8 @@ class Diff:
         )
         with tempfile.NamedTemporaryFile(delete=False, prefix="git-difftool-", suffix=".html") as writer:
             writer.write(html_begin)
+            if commit_metadata := os.getenv("COMMIT_METADATA"):
+                writer.write(f"<div><pre>{commit_metadata}</pre></div>".encode())
             self._report(left_right_files, writer)
             writer.write(html_end)
         return Path(writer.name)
@@ -278,6 +281,7 @@ class Diff:
 def main():
     diff = Diff(sys.argv[1], sys.argv[2])
     html_file = diff.report()
+    print(html_file)  # noqa: T201
     webbrowser.open(html_file.as_uri())
 
 


### PR DESCRIPTION
I had removed the line 

```python
print(html_file)  # noqa: T201
```

because I thought it was no longer needed, and cluttered the output, which now also contained the equivalent `git dd` command when running `git ss`. But it is needed for the basic test I have added in GitHub Actions.