### PR TITLE
Configure IPython to use the Gruvbox theme

### DIFF
--- a/.ipython/profile_default/ipython_config.py
+++ b/.ipython/profile_default/ipython_config.py
@@ -26,6 +26,6 @@ c.Completer.backslash_combining_completions = True
 
 if IPython.version_info < (9,):
     c.TerminalInteractiveShell.highlighting_style = "gruvbox-dark"
-if IPython.version_info >= (9,):
-    c.InteractiveShell.colors = "neutral"
+else:
+    c.InteractiveShell.colors = "neutral" if IPython.version_info < (9, 7) else "gruvbox-dark"
     c.InteractiveShell.enable_tip = False


### PR DESCRIPTION
I contributed this theme to IPython, and it is now available in version 9.7.0. 