### PR TITLE
Handle focus reporting race

### DIFF
--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -101,8 +101,6 @@ bool terminal_has_focus(void)
         {
             return false;
         }
-        // Enable focus reporting.
-        std::clog << "\x1b\x5b?1004h";
         // Consume standard input so that anything entered previously does not
         // get read instead of the focus escape sequence.
         while (true)
@@ -117,6 +115,8 @@ bool terminal_has_focus(void)
                 break;
             }
         }
+        // Enable focus reporting.
+        std::clog << "\x1b\x5b?1004h";
         count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
         // Disable focus reporting. If it is disabled immediately after
         // enabling it instead of here, the terminal may never send any focus

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -101,48 +101,47 @@ bool terminal_has_focus(void)
         {
             return false;
         }
-        // Consume standard input so that anything entered previously does not
-        // get read instead of the focus escape sequence.
-        while (true)
+        // Consume standard input so that anything entered previously is
+        // removed and it is ready to receive the focus escape sequence. There
+        // is a small chance that the user types something after consuming
+        // standard input but before the terminal sends the sequence. This rare
+        // failure is all right.
+        while ((count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf)) > 0)
         {
-            count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
-            if (count < 0)
-            {
-                return false;
-            }
-            if (count == 0)
-            {
-                break;
-            }
         }
-        // Enable focus reporting.
-        std::clog << "\x1b\x5b?1004h";
-        count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
-        // Disable focus reporting. If it is disabled immediately after
-        // enabling it instead of here, the terminal may never send any focus
-        // escape sequences. There is a small chance that the sequences get
-        // written to standard input before focus reporting gets disabled but
-        // after the previous sequences have been read. It should cause no
-        // damage, so I'll allow it.
-        std::clog << "\x1b\x5b?1004l";
+        if (count < 0)
+        {
+            return false;
+        }
     }
-    LOG_DEBUG(logger, "Read non-blocking standard input", { { "count", count } });
-    if (count <= 0)
-    {
-        return false;
-    }
-    std::string_view buf_view(buf, count);
-    size_t focus_out_seq_pos = buf_view.rfind("\x1b\x5bO");
-    if (focus_out_seq_pos == std::string_view::npos)
-    {
-        return true;
-    }
-    size_t focus_in_seq_pos = buf_view.rfind("\x1b\x5bI");
-    if (focus_in_seq_pos == std::string_view::npos)
-    {
-        return false;
-    }
-    return focus_out_seq_pos < focus_in_seq_pos;
+    // Enable focus reporting.
+    std::clog << "\x1b\x5b?1004h";
+    count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
+    // Disable focus reporting. If it is disabled immediately after
+    // enabling it instead of here, the terminal may never send any focus
+    // escape sequences. There is a small chance that more sequences get
+    // written to standard input before focus reporting gets disabled but after
+    // the previous sequences have been read. This rare failure is all right.
+    std::clog << "\x1b\x5b?1004l";
+}
+
+LOG_DEBUG(logger, "Read non-blocking standard input", { { "count", count } });
+if (count <= 0)
+{
+    return false;
+}
+std::string_view buf_view(buf, count);
+size_t focus_out_seq_pos = buf_view.rfind("\x1b\x5bO");
+if (focus_out_seq_pos == std::string_view::npos)
+{
+    return true;
+}
+size_t focus_in_seq_pos = buf_view.rfind("\x1b\x5bI");
+if (focus_in_seq_pos == std::string_view::npos)
+{
+    return false;
+}
+return focus_out_seq_pos < focus_in_seq_pos;
 }
 
 #endif

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -102,10 +102,10 @@ bool terminal_has_focus(void)
             return false;
         }
         // Consume standard input so that anything entered previously is
-        // removed and it is ready to receive the focus escape sequence. There
-        // is a small chance that the user types something after consuming
-        // standard input but before the terminal sends the sequence. This rare
-        // failure is all right.
+        // removed and it is ready to receive focus escape sequences. There is
+        // a small chance that the user types something after consuming
+        // standard input but before the terminal sends the sequences. This
+        // rare failure is acceptable.
         while ((count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf)) > 0)
         {
         }
@@ -117,11 +117,11 @@ bool terminal_has_focus(void)
     // Enable focus reporting.
     std::clog << "\x1b\x5b?1004h";
     count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
-    // Disable focus reporting. If it is disabled immediately after
-    // enabling it instead of here, the terminal may never send any focus
-    // escape sequences. There is a small chance that more sequences get
-    // written to standard input before focus reporting gets disabled but after
-    // the previous sequences have been read. This rare failure is all right.
+    // Disable focus reporting. If it is disabled immediately after enabling it
+    // instead of here, the terminal may never send any focus escape sequences.
+    // There is a small chance that more sequences get written to standard
+    // input before focus reporting gets disabled but after the previous
+    // sequences have been read. This rare failure is acceptable.
     std::clog << "\x1b\x5b?1004l";
 }
 

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -101,13 +101,15 @@ bool terminal_has_focus(void)
         {
             return false;
         }
+
         // Consume standard input so that anything entered previously is
         // removed and it is ready to receive focus escape sequences. There is
-        // a small chance that the user types something after consuming
-        // standard input but before the terminal sends the sequences. This
-        // rare failure is acceptable.
+        // a small chance that the user types something after standard input is
+        // consumed but before the terminal sends the sequences. This rare
+        // failure is acceptable.
         while ((count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf)) > 0)
         {
+            LOG_DEBUG(logger, "Cleared standard input", { { "count", count } });
         }
         if (count < 0)
         {
@@ -117,11 +119,13 @@ bool terminal_has_focus(void)
         // Enable focus reporting.
         std::clog << "\x1b\x5b?1004h";
         count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
-        // Disable focus reporting. If it is disabled immediately after enabling it
-        // instead of here, the terminal may never send any focus escape sequences.
-        // There is a small chance that more sequences get written to standard
-        // input before focus reporting gets disabled but after the previous
-        // sequences have been read. This rare failure is acceptable.
+
+        // Disable focus reporting. If it is disabled immediately after
+        // enabling it instead of here, the terminal may never send any focus
+        // escape sequences. There is a small chance that more sequences get
+        // written to standard input before focus reporting gets disabled but
+        // after the previous sequences have been read. This rare failure is
+        // acceptable.
         std::clog << "\x1b\x5b?1004l";
     }
 

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -33,42 +33,51 @@ bool terminal_has_focus(void)
 #include <termios.h>
 #include <unistd.h>
 
-#define BUFSIZE 255
-
 /**
  * Temporarily modify standard input to allow non-blocking reads.
  */
 class NonBlockingStandardInputGuard
 {
 private:
-    bool error_occurred;
+    bool m_error_occurred;
     termios prev_termios, curr_termios;
 
 public:
     NonBlockingStandardInputGuard(void);
+    bool error_occurred(void) const;
     ~NonBlockingStandardInputGuard();
 };
 
 /**
  * Enable non-canonical mode.
  */
-NonBlockingStandardInputGuard::NonBlockingStandardInputGuard(void) : error_occurred(false)
+NonBlockingStandardInputGuard::NonBlockingStandardInputGuard(void) : m_error_occurred(false)
 {
     if (tcgetattr(STDIN_FILENO, &this->prev_termios) == -1)
     {
-        this->error_occurred = true;
+        this->m_error_occurred = true;
         return;
     }
     this->curr_termios = this->prev_termios;
     this->curr_termios.c_lflag &= ~(ECHO | ICANON);
-    // Block until sufficiently many bytes are available from standard input.
-    this->curr_termios.c_cc[VMIN] = BUFSIZE;
-    // But not for too long.
+    // Read standard input with a timeout.
+    this->curr_termios.c_cc[VMIN] = 0;
     this->curr_termios.c_cc[VTIME] = 1;
     if (tcsetattr(STDIN_FILENO, TCSANOW, &this->curr_termios) == -1)
     {
-        this->error_occurred = true;
+        this->m_error_occurred = true;
     }
+}
+
+/**
+ * Check whether an error occurred while trying to get or set terminal
+ * attributes.
+ *
+ * @return Error indicator.
+ */
+bool NonBlockingStandardInputGuard::error_occurred(void) const
+{
+    return this->m_error_occurred;
 }
 
 /**
@@ -76,7 +85,7 @@ NonBlockingStandardInputGuard::NonBlockingStandardInputGuard(void) : error_occur
  */
 NonBlockingStandardInputGuard::~NonBlockingStandardInputGuard()
 {
-    if (!this->error_occurred)
+    if (!this->m_error_occurred)
     {
         tcsetattr(STDIN_FILENO, TCSANOW, &this->prev_termios);
     }
@@ -84,13 +93,24 @@ NonBlockingStandardInputGuard::~NonBlockingStandardInputGuard()
 
 bool terminal_has_focus(void)
 {
-    char buf[BUFSIZE];
+    char buf[1024];
     ssize_t count;
     {
-        NonBlockingStandardInputGuard _;
-        // Enable and immediately disable focus reporting.
-        std::clog << "\x1b\x5b?1004h\x1b\x5b?1004l";
+        NonBlockingStandardInputGuard guard;
+        if (guard.error_occurred())
+        {
+            return false;
+        }
+        // Enable focus reporting.
+        std::clog << "\x1b\x5b?1004h";
         count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
+        // Disable focus reporting. If it is disabled immediately after
+        // enabling it instead of here, the terminal may never send any focus
+        // escape sequences. There is a small chance that the sequences get
+        // written to standard input before focus reporting gets disabled but
+        // after the previous sequences have been read. It should cause no
+        // damage, so I'll allow it.
+        std::clog << "\x1b\x5b?1004l";
     }
     LOG_DEBUG(logger, "Read non-blocking standard input", { { "count", count } });
     if (count <= 0)

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -60,7 +60,7 @@ NonBlockingStandardInputGuard::NonBlockingStandardInputGuard(void) : m_error_occ
     }
     this->curr_termios = this->prev_termios;
     this->curr_termios.c_lflag &= ~(ECHO | ICANON);
-    // Read standard input with a timeout.
+    // Set a timeout on standard input reads.
     this->curr_termios.c_cc[VMIN] = 0;
     this->curr_termios.c_cc[VTIME] = 1;
     if (tcsetattr(STDIN_FILENO, TCSANOW, &this->curr_termios) == -1)

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -96,6 +96,13 @@ bool terminal_has_focus(void)
     char buf[1024];
     ssize_t count;
     {
+        NonBlockingStandardInputGuard guard;
+        if (guard.error_occurred())
+        {
+            return false;
+        }
+        // Enable focus reporting.
+        std::clog << "\x1b\x5b?1004h";
         // Consume standard input so that anything entered previously does not
         // get read instead of the focus escape sequence.
         while (true)
@@ -110,13 +117,6 @@ bool terminal_has_focus(void)
                 break;
             }
         }
-        NonBlockingStandardInputGuard guard;
-        if (guard.error_occurred())
-        {
-            return false;
-        }
-        // Enable focus reporting.
-        std::clog << "\x1b\x5b?1004h";
         count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
         // Disable focus reporting. If it is disabled immediately after
         // enabling it instead of here, the terminal may never send any focus

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -96,6 +96,20 @@ bool terminal_has_focus(void)
     char buf[1024];
     ssize_t count;
     {
+        // Consume standard input so that anything entered previously does not
+        // get read instead of the focus escape sequence.
+        while (true)
+        {
+            count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
+            if (count < 0)
+            {
+                return false;
+            }
+            if (count == 0)
+            {
+                break;
+            }
+        }
         NonBlockingStandardInputGuard guard;
         if (guard.error_occurred())
         {

--- a/custom-prompt/focus_utils.cc
+++ b/custom-prompt/focus_utils.cc
@@ -113,35 +113,35 @@ bool terminal_has_focus(void)
         {
             return false;
         }
-    }
-    // Enable focus reporting.
-    std::clog << "\x1b\x5b?1004h";
-    count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
-    // Disable focus reporting. If it is disabled immediately after enabling it
-    // instead of here, the terminal may never send any focus escape sequences.
-    // There is a small chance that more sequences get written to standard
-    // input before focus reporting gets disabled but after the previous
-    // sequences have been read. This rare failure is acceptable.
-    std::clog << "\x1b\x5b?1004l";
-}
 
-LOG_DEBUG(logger, "Read non-blocking standard input", { { "count", count } });
-if (count <= 0)
-{
-    return false;
-}
-std::string_view buf_view(buf, count);
-size_t focus_out_seq_pos = buf_view.rfind("\x1b\x5bO");
-if (focus_out_seq_pos == std::string_view::npos)
-{
-    return true;
-}
-size_t focus_in_seq_pos = buf_view.rfind("\x1b\x5bI");
-if (focus_in_seq_pos == std::string_view::npos)
-{
-    return false;
-}
-return focus_out_seq_pos < focus_in_seq_pos;
+        // Enable focus reporting.
+        std::clog << "\x1b\x5b?1004h";
+        count = read(STDIN_FILENO, buf, sizeof buf / sizeof *buf);
+        // Disable focus reporting. If it is disabled immediately after enabling it
+        // instead of here, the terminal may never send any focus escape sequences.
+        // There is a small chance that more sequences get written to standard
+        // input before focus reporting gets disabled but after the previous
+        // sequences have been read. This rare failure is acceptable.
+        std::clog << "\x1b\x5b?1004l";
+    }
+
+    LOG_DEBUG(logger, "Read non-blocking standard input", { { "count", count } });
+    if (count <= 0)
+    {
+        return false;
+    }
+    std::string_view buf_view(buf, count);
+    size_t focus_out_seq_pos = buf_view.rfind("\x1b\x5bO");
+    if (focus_out_seq_pos == std::string_view::npos)
+    {
+        return true;
+    }
+    size_t focus_in_seq_pos = buf_view.rfind("\x1b\x5bI");
+    if (focus_in_seq_pos == std::string_view::npos)
+    {
+        return false;
+    }
+    return focus_out_seq_pos < focus_in_seq_pos;
 }
 
 #endif


### PR DESCRIPTION
* Disable focus reporting after reading standard input
  * Some slow terminals may batch process the enable and disable requests if they are sent in succession.
  * The terminal may then not send focus escape sequences at all.
* Make the standard input read time out from the start of the read instead of after a byte is available
  * The aforementioned slow terminals may not send escape sequences, so the read will then block forever.
* Check for errors getting or setting terminal attributes before enabling focus reporting
* Clear standard input before enabling focus reporting