### PR TITLE
Use `strtod` instead of `from_chars` as Clang does not support it

### DIFF
--- a/custom-prompt/Makefile
+++ b/custom-prompt/Makefile
@@ -1,5 +1,5 @@
 CPPFLAGS = $(shell pkg-config --cflags libgit2)
-CXXFLAGS = -fstrict-aliasing -std=c++17 -Wall -Wextra -Wno-unused-parameter
+CXXFLAGS = -fstrict-aliasing -std=c++20 -Wall -Wextra -Wno-unused-parameter
 LDLIBS = -lstdc++ $(shell pkg-config --libs libgit2)
 
 MainSource = custom-prompt.cc

--- a/custom-prompt/Makefile
+++ b/custom-prompt/Makefile
@@ -1,5 +1,5 @@
 CPPFLAGS = $(shell pkg-config --cflags libgit2)
-CXXFLAGS = -fstrict-aliasing -std=c++20 -Wall -Wextra -Wno-unused-parameter
+CXXFLAGS = -fstrict-aliasing -std=c++17 -Wall -Wextra -Wno-unused-parameter
 LDLIBS = -lstdc++ $(shell pkg-config --libs libgit2)
 
 MainSource = custom-prompt.cc

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -106,7 +106,7 @@ static JSONLogger logger;
  *
  * @return Value obtained after parsing.
  */
-template <typename T> T from_chars(std::string_view view, T otherwise)
+template <typename T> T parse_string_to_integer(std::string_view view, T otherwise)
 {
     T result = otherwise;
     std::from_chars(view.data(), view.data() + view.size(), result);
@@ -772,15 +772,15 @@ int main_internal(int const argc, char const* argv[])
         .detach();
 
     std::string_view last_command(argv[1]);
-    int exit_code = from_chars(argv[2], 1);
+    int exit_code = parse_string_to_integer(argv[2], 1);
     double begin_ts = std::strtod(argv[3], nullptr);
     double end_ts = std::strtod(argv[4], nullptr);
     double delay = end_ts - begin_ts;
-    std::size_t columns = from_chars(argv[5], 79);
+    std::size_t columns = parse_string_to_integer(argv[5], 79);
     report_command_status(last_command, exit_code, delay, columns);
 
     std::string_view pwd(argv[6]);
-    int shlvl = from_chars(argv[7], 1);
+    int shlvl = parse_string_to_integer(argv[7], 1);
     std::string_view venv_view;
     char const* venv;
     if ((venv = getenv("VIRTUAL_ENV_PROMPT")) != nullptr)

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -96,14 +96,22 @@ namespace C
 
 // clang-format on
 
-#define FROM_CHARS(type, name, value, source)                                                                         \
-    type name = value;                                                                                                \
-    {                                                                                                                 \
-        std::string_view name_view(source);                                                                           \
-        std::from_chars(name_view.data(), name_view.data() + name_view.size(), name);                                 \
-    }
-
 static JSONLogger logger;
+
+/**
+ * Fast parser which converts a string to a value of the desired type.
+ *
+ * @param view String to parse.
+ * @param otherwise Value to return if parsing fails.
+ *
+ * @return Value obtained after parsing.
+ */
+template<typename T>
+T from_chars(std::string_view view, T otherwise){
+    T result = otherwise;
+    std::from_chars(view.data(), view.data() + view.size(), result);
+    return result;
+}
 
 /**
  * Represent an amount of time.
@@ -764,15 +772,15 @@ int main_internal(int const argc, char const* argv[])
         .detach();
 
     std::string_view last_command(argv[1]);
-    FROM_CHARS(int, exit_code, 1, argv[2]);
+    int exit_code = from_chars(argv[2], 1);
     double begin_ts = std::strtod(argv[3], nullptr);
     double end_ts = std::strtod(argv[4], nullptr);
     double delay = end_ts - begin_ts;
-    FROM_CHARS(std::size_t, columns, 79, argv[5]);
+    std::size_t columns = from_chars(argv[5], 79);
     report_command_status(last_command, exit_code, delay, columns);
 
     std::string_view pwd(argv[6]);
-    FROM_CHARS(int, shlvl, 1, argv[7]);
+    int shlvl = from_chars(argv[7], 1);
     std::string_view venv_view;
     char const* venv;
     if ((venv = getenv("VIRTUAL_ENV_PROMPT")) != nullptr)

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -96,6 +96,13 @@ namespace C
 
 // clang-format on
 
+#define FROM_CHARS(type, name, value, source)                                                                         \
+    type name = value;                                                                                                \
+    {                                                                                                                 \
+        std::string_view name_view(source);                                                                           \
+        std::from_chars(name_view.data(), name_view.data() + name_view.size(), name);                                 \
+    }
+
 static JSONLogger logger;
 
 /**
@@ -757,18 +764,15 @@ int main_internal(int const argc, char const* argv[])
         .detach();
 
     std::string_view last_command(argv[1]);
-    int exit_code = std::stoi(argv[2]);
-    double begin_ts, end_ts;
-    std::string_view begin_ts_view(argv[3]);
-    std::from_chars(begin_ts_view.data(), begin_ts_view.data() + begin_ts_view.size(), begin_ts);
-    std::string_view end_ts_view(argv[4]);
-    std::from_chars(end_ts_view.data(), end_ts_view.data() + end_ts_view.size(), end_ts);
+    FROM_CHARS(int, exit_code, 1, argv[2]);
+    double begin_ts = std::strtod(argv[3], nullptr);
+    double end_ts = std::strtod(argv[4], nullptr);
     double delay = end_ts - begin_ts;
-    std::size_t columns = std::stoull(argv[5]);
+    FROM_CHARS(std::size_T, columns, 79, argv[5]);
     report_command_status(last_command, exit_code, delay, columns);
 
     std::string_view pwd(argv[6]);
-    int shlvl = std::stoi(argv[7]);
+    FROM_CHARS(int, shlvl, 1, argv[7]);
     std::string_view venv_view;
     char const* venv;
     if ((venv = getenv("VIRTUAL_ENV_PROMPT")) != nullptr)

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -99,7 +99,9 @@ namespace C
 static JSONLogger logger;
 
 /**
- * Fast parser which converts a string to an integer.
+ * Fast parser which converts (the prefix of) a string to an integer. (With
+ * some compilers, this may work for floating-point numbers as well, but this
+ * is not guaranteed.)
  *
  * @param view String to parse.
  * @param otherwise Fallback integer to return if parsing fails.

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -106,8 +106,8 @@ static JSONLogger logger;
  *
  * @return Value obtained after parsing.
  */
-template<typename T>
-T from_chars(std::string_view view, T otherwise){
+template <typename T> T from_chars(std::string_view view, T otherwise)
+{
     T result = otherwise;
     std::from_chars(view.data(), view.data() + view.size(), result);
     return result;

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -99,16 +99,14 @@ namespace C
 static JSONLogger logger;
 
 /**
- * Fast parser which converts (the prefix of) a string to an integer. (With
- * some compilers, this may work for floating-point numbers as well, but this
- * is not guaranteed.)
+ * Try to convert a string to an integer.
  *
  * @param view String to parse.
  * @param otherwise Fallback integer to return if parsing fails.
  *
- * @return The resultant integer if parsing succeeds, else the fallback.
+ * @return The parsed integer or the fallback.
  */
-template <typename T> T parse_string_to_integer(std::string_view view, T otherwise)
+template <typename T> T try_parse_number(std::string_view view, T otherwise)
 {
     T result = otherwise;
     std::from_chars(view.data(), view.data() + view.size(), result);
@@ -774,15 +772,17 @@ int main_internal(int const argc, char const* argv[])
         .detach();
 
     std::string_view last_command(argv[1]);
-    int exit_code = parse_string_to_integer(argv[2], 1);
+    int exit_code = try_parse_number(argv[2], 1);
+    // Support for parsing floating-point numbers is not consistent across
+    // standard library implementations, so use a different function.
     double begin_ts = std::strtod(argv[3], nullptr);
     double end_ts = std::strtod(argv[4], nullptr);
     double delay = end_ts - begin_ts;
-    std::size_t columns = parse_string_to_integer(argv[5], 79);
+    std::size_t columns = try_parse_number(argv[5], 79);
     report_command_status(last_command, exit_code, delay, columns);
 
     std::string_view pwd(argv[6]);
-    int shlvl = parse_string_to_integer(argv[7], 1);
+    int shlvl = try_parse_number(argv[7], 1);
     std::string_view venv_view;
     char const* venv;
     if ((venv = getenv("VIRTUAL_ENV_PROMPT")) != nullptr)

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -768,7 +768,7 @@ int main_internal(int const argc, char const* argv[])
     double begin_ts = std::strtod(argv[3], nullptr);
     double end_ts = std::strtod(argv[4], nullptr);
     double delay = end_ts - begin_ts;
-    FROM_CHARS(std::size_T, columns, 79, argv[5]);
+    FROM_CHARS(std::size_t, columns, 79, argv[5]);
     report_command_status(last_command, exit_code, delay, columns);
 
     std::string_view pwd(argv[6]);

--- a/custom-prompt/custom-prompt.cc
+++ b/custom-prompt/custom-prompt.cc
@@ -99,12 +99,12 @@ namespace C
 static JSONLogger logger;
 
 /**
- * Fast parser which converts a string to a value of the desired type.
+ * Fast parser which converts a string to an integer.
  *
  * @param view String to parse.
- * @param otherwise Value to return if parsing fails.
+ * @param otherwise Fallback integer to return if parsing fails.
  *
- * @return Value obtained after parsing.
+ * @return The resultant integer if parsing succeeds, else the fallback.
  */
 template <typename T> T parse_string_to_integer(std::string_view view, T otherwise)
 {


### PR DESCRIPTION
Use `from_chars` to parse all integers, though.